### PR TITLE
Fix the problem that can't not compile with gcc6.3

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -20,12 +20,6 @@ inline float sign(float f)
 	return f<0.0f?-1.0f:1.0f;
 }
 
-inline int round(float f)
-{
-	if(f > 0)
-		return (int)(f+0.5f);
-	return (int)(f-0.5f);
-}
 
 template<typename T, typename TB>
 inline T mix(const T a, const T b, TB amount)


### PR DESCRIPTION
Delete the function int round(float) in src/base/math.h and every thing is going well.

#2 